### PR TITLE
fix(makefile): default PLATFORM to host arch, add run target

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -1,0 +1,97 @@
+name: Base Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'dockerfiles/Dockerfile.base'
+      - 'dockerfiles/build/debugbox-base-profile'
+      - '.github/workflows/base.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-scan-push:
+    name: Build, Scan & Push
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+      fail-fast: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ matrix.arch }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build base image (${{ matrix.arch }})
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerfiles/Dockerfile.base
+          platforms: linux/${{ matrix.arch }}
+          load: true
+          push: false
+          tags: debugbox-base:ci
+
+      - name: Install Trivy
+        run: |
+          set -e
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+            | sh -s -- -b /usr/local/bin v0.72.0
+          trivy --version
+
+      - name: Trivy security scan
+        run: |
+          trivy image \
+            --severity HIGH,CRITICAL \
+            --exit-code 1 \
+            debugbox-base:ci
+
+      - name: Report size
+        run: |
+          SIZE_BYTES=$(docker save debugbox-base:ci | gzip -c | wc -c)
+          SIZE_MB=$(awk "BEGIN {printf \"%.2f\", $SIZE_BYTES / 1024 / 1024}")
+          echo "📦 [${{ matrix.arch }}] base compressed: ${SIZE_MB} MB"
+
+  push:
+    name: Push Multi-Arch
+    needs: build-scan-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64,arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push base image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerfiles/Dockerfile.base
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/ibtisam-iq/debugbox-base:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           set -e
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
-            | sh -s -- -b /usr/local/bin v0.69.1
+            | sh -s -- -b /usr/local/bin v0.72.0
           trivy --version
 
       - name: Build ${{ matrix.variant }} image for ${{ matrix.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,13 @@ permissions:
   contents: read
 
 jobs:
-  build-and-smoke-test:
-    name: Build & Test
+  build-base:
+    name: Build Base
     runs-on: ubuntu-latest
     strategy:
       matrix:
         arch: [amd64, arm64]
-        variant: [base, lite, balanced, power]
-      fail-fast: true
+      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,6 +40,54 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Build base image for ${{ matrix.arch }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerfiles/Dockerfile.base
+          platforms: linux/${{ matrix.arch }}
+          outputs: type=docker,dest=/tmp/debugbox-base-${{ matrix.arch }}.tar
+          tags: debugbox-base:ci
+
+      - name: Upload base image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: debugbox-base-${{ matrix.arch }}
+          path: /tmp/debugbox-base-${{ matrix.arch }}.tar
+          retention-days: 1
+
+  build-and-test:
+    name: Build & Test
+    needs: build-base
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        variant: [base, lite, balanced, power]
+      fail-fast: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ matrix.arch }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Download base image artifact
+        if: matrix.variant != 'base'
+        uses: actions/download-artifact@v4
+        with:
+          name: debugbox-base-${{ matrix.arch }}
+          path: /tmp
+
+      - name: Load base image
+        if: matrix.variant != 'base'
+        run: docker load -i /tmp/debugbox-base-${{ matrix.arch }}.tar
 
       - name: Extract metadata for ${{ matrix.variant }}
         id: meta
@@ -72,6 +119,8 @@ jobs:
           push: false
           tags: debugbox-${{ matrix.variant }}:ci
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_IMAGE=debugbox-base:ci
 
       - name: Verify labels and report size
         run: |
@@ -94,9 +143,8 @@ jobs:
             -v ${{ github.workspace }}/tests:/tests:ro \
             debugbox-${{ matrix.variant }}:ci \
             sh /tests/ci-smoke.sh
-            
+
       - name: Trivy security scan
-        # if: matrix.variant != 'base'
         run: |
           trivy image \
             --severity HIGH,CRITICAL \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,49 +22,13 @@ permissions:
   contents: read
 
 jobs:
-  build-base:
-    name: Build Base
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [amd64, arm64]
-      fail-fast: false
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: ${{ matrix.arch }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build base image for ${{ matrix.arch }}
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: dockerfiles/Dockerfile.base
-          platforms: linux/${{ matrix.arch }}
-          outputs: type=docker,dest=/tmp/debugbox-base-${{ matrix.arch }}.tar
-          tags: debugbox-base:ci
-
-      - name: Upload base image artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: debugbox-base-${{ matrix.arch }}
-          path: /tmp/debugbox-base-${{ matrix.arch }}.tar
-          retention-days: 1
-
-  build-and-test:
+  build-and-smoke-test:
     name: Build & Test
-    needs: build-base
     runs-on: ubuntu-latest
     strategy:
       matrix:
         arch: [amd64, arm64]
-        variant: [base, lite, balanced, power]
+        variant: [lite, balanced, power]
       fail-fast: false
     steps:
       - name: Checkout repository
@@ -77,17 +41,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Download base image artifact
-        if: matrix.variant != 'base'
-        uses: actions/download-artifact@v4
-        with:
-          name: debugbox-base-${{ matrix.arch }}
-          path: /tmp
-
-      - name: Load base image
-        if: matrix.variant != 'base'
-        run: docker load -i /tmp/debugbox-base-${{ matrix.arch }}.tar
 
       - name: Extract metadata for ${{ matrix.variant }}
         id: meta
@@ -119,8 +72,6 @@ jobs:
           push: false
           tags: debugbox-${{ matrix.variant }}:ci
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            BASE_IMAGE=debugbox-base:ci
 
       - name: Verify labels and report size
         run: |
@@ -136,8 +87,7 @@ jobs:
           SIZE_MB=$(awk "BEGIN {printf \"%.2f\", $SIZE_BYTES / 1024 / 1024}")
           echo "📦 [${{ matrix.arch }}] ${{ matrix.variant }} compressed: ${SIZE_MB} MB"
 
-      - name: CI smoke test - ${{ matrix.variant }}
-        if: matrix.variant != 'base'
+      - name: CI smoke test
         run: |
           docker run --rm \
             -v ${{ github.workspace }}/tests:/tests:ro \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ TESTS_DIR         := tests
 
 # Local build configuration
 LOCAL_TAG ?= local
-PLATFORM  ?= linux/amd64,linux/arm64
+HOST_ARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+PLATFORM  ?= linux/$(HOST_ARCH)
 NO_CACHE  ?= false
 
 # Tooling
@@ -37,6 +38,9 @@ help:
 	@echo "  make build-<variant>     Build image (lite | balanced | power)"
 	@echo "  make build-all           Build all variants"
 	@echo ""
+	@echo "Run:"
+	@echo "  make run-<variant>       Run variant interactively"
+	@echo ""
 	@echo "Test:"
 	@echo "  make test-<variant>      Run smoke tests"
 	@echo "  make test-all            Test all variants"
@@ -50,7 +54,7 @@ help:
 	@echo "  make clean               Remove local images"
 	@echo ""
 	@echo "Args:"
-	@echo "  PLATFORM=linux/amd64     Override platforms"
+	@echo "  PLATFORM=linux/amd64     Override platform (default: host arch)"
 	@echo "  NO_CACHE=true            Disable build cache"
 	@echo ""
 
@@ -134,6 +138,14 @@ test-all: build-all
 	done
 	@echo "✅ All tests passed"
 	@echo ""
+
+# -------------------------------
+# Run
+# -------------------------------
+.PHONY: run-%
+run-%:
+	@echo "==> Running $(IMAGE_NAME):$*-$(LOCAL_TAG)"
+	docker run --rm -it $(IMAGE_NAME):$*-$(LOCAL_TAG)
 
 # -------------------------------
 # Security scan

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ TRIVY           ?= trivy
 
 # Docker
 DOCKER_BUILD := docker buildx build
+BASE_IMAGE   ?= $(IMAGE_NAME):base-$(LOCAL_TAG)
 
 # -------------------------------
 # Help
@@ -66,6 +67,7 @@ define docker_build
 	$(DOCKER_BUILD) \
 		--platform $(PLATFORM) \
 		$(if $(filter true,$(NO_CACHE)),--no-cache,) \
+		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--load \
 		-f $(DOCKERFILES_DIR)/Dockerfile.$1 \
 		-t $(IMAGE_NAME):$1-$(LOCAL_TAG) \
@@ -116,8 +118,12 @@ lint:
 build-%:
 	$(call docker_build,$*)
 
+.PHONY: build-base
+build-base:
+	$(call docker_build,base)
+
 .PHONY: build-all
-build-all: lint
+build-all: lint build-base
 	@for v in $(VARIANTS); do \
 		$(MAKE) build-$$v || exit 1; \
 	done
@@ -176,6 +182,7 @@ check: lint build-all test-all scan
 .PHONY: clean
 clean:
 	@echo "==> Cleaning local images"
+	@docker rmi -f $(IMAGE_NAME):base-$(LOCAL_TAG) >/dev/null 2>&1 || true
 	@for v in $(VARIANTS); do \
 		docker rmi -f $(IMAGE_NAME):$$v-$(LOCAL_TAG) >/dev/null 2>&1 || true; \
 	done

--- a/dockerfiles/Dockerfile.balanced
+++ b/dockerfiles/Dockerfile.balanced
@@ -20,7 +20,8 @@ RUN CGO_ENABLED=0 go build -trimpath \
       -o kubens ./cmd/kubens
 
 # Runtime image
-FROM ghcr.io/ibtisam-iq/debugbox-base:latest
+ARG BASE_IMAGE=ghcr.io/ibtisam-iq/debugbox-base:latest
+FROM ${BASE_IMAGE}
 
 # Build args for OCI labels (passed from workflow)
 ARG BUILD_DATE
@@ -31,7 +32,7 @@ ARG VERSION
 LABEL org.opencontainers.image.title="DebugBox Balanced" \
       org.opencontainers.image.description="Balanced debugging image for everyday Kubernetes and cloud-native troubleshooting" \
       org.opencontainers.image.variant="balanced" \
-      org.opencontainers.image.base.name="ghcr.io/ibtisam-iq/debugbox-base:latest" \
+      org.opencontainers.image.base.name="${BASE_IMAGE}" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.version="${VERSION}" \

--- a/dockerfiles/Dockerfile.balanced
+++ b/dockerfiles/Dockerfile.balanced
@@ -1,6 +1,8 @@
 # DebugBox — Balanced variant
 # Daily-driver debugging image for Kubernetes troubleshooting (~46 MB).
 
+ARG BASE_IMAGE=ghcr.io/ibtisam-iq/debugbox-base:latest
+
 # Build kubectx/kubens from source
 FROM golang:1.25-alpine AS kubectx-builder
 
@@ -20,7 +22,6 @@ RUN CGO_ENABLED=0 go build -trimpath \
       -o kubens ./cmd/kubens
 
 # Runtime image
-ARG BASE_IMAGE=ghcr.io/ibtisam-iq/debugbox-base:latest
 FROM ${BASE_IMAGE}
 
 # Build args for OCI labels (passed from workflow)

--- a/dockerfiles/Dockerfile.base
+++ b/dockerfiles/Dockerfile.base
@@ -4,14 +4,14 @@
 # Push Command: docker buildx build --platform linux/amd64,linux/arm64 \
 #                    -t ghcr.io/ibtisam-iq/debugbox-base:latest -f dockerfiles/Dockerfile.base --push .
 
-FROM alpine:3.20.9
+FROM alpine:3.20.10
 
 # OCI image labels
 LABEL org.opencontainers.image.title="DebugBox Base" \
       org.opencontainers.image.description="Minimal Alpine base image for DebugBox Kubernetes debugging containers" \
       org.opencontainers.image.version="base-1.0.0" \
       org.opencontainers.image.variant="base" \
-      org.opencontainers.image.base.name="alpine:3.20.9" \
+      org.opencontainers.image.base.name="alpine:3.20.10" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.url="https://github.com/ibtisam-iq/debugbox" \
       org.opencontainers.image.source="https://github.com/ibtisam-iq/debugbox" \

--- a/dockerfiles/Dockerfile.lite
+++ b/dockerfiles/Dockerfile.lite
@@ -1,7 +1,8 @@
 # DebugBox — Lite variant
 # Minimal debugging image for quick Kubernetes network diagnostics (~14 MB).
 
-FROM ghcr.io/ibtisam-iq/debugbox-base:latest
+ARG BASE_IMAGE=ghcr.io/ibtisam-iq/debugbox-base:latest
+FROM ${BASE_IMAGE}
 
 # Build args for OCI labels (passed from workflow)
 ARG BUILD_DATE
@@ -12,7 +13,7 @@ ARG VERSION
 LABEL org.opencontainers.image.title="DebugBox Lite" \
       org.opencontainers.image.description="Minimal debugging image for quick Kubernetes checks and ephemeral containers" \
       org.opencontainers.image.variant="lite" \
-      org.opencontainers.image.base.name="ghcr.io/ibtisam-iq/debugbox-base:latest" \
+      org.opencontainers.image.base.name="${BASE_IMAGE}" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.version="${VERSION}" \

--- a/dockerfiles/Dockerfile.power
+++ b/dockerfiles/Dockerfile.power
@@ -20,7 +20,8 @@ RUN CGO_ENABLED=0 go build -trimpath \
       -o kubens ./cmd/kubens
 
 # Runtime image
-FROM ghcr.io/ibtisam-iq/debugbox-base:latest
+ARG BASE_IMAGE=ghcr.io/ibtisam-iq/debugbox-base:latest
+FROM ${BASE_IMAGE}
 
 # Build args for OCI labels (passed from workflow)
 ARG BUILD_DATE
@@ -31,7 +32,7 @@ ARG VERSION
 LABEL org.opencontainers.image.title="DebugBox Power" \
       org.opencontainers.image.description="Advanced SRE-grade network forensics and troubleshooting image" \
       org.opencontainers.image.variant="power" \
-      org.opencontainers.image.base.name="ghcr.io/ibtisam-iq/debugbox-base:latest" \
+      org.opencontainers.image.base.name="${BASE_IMAGE}" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.version="${VERSION}" \

--- a/dockerfiles/Dockerfile.power
+++ b/dockerfiles/Dockerfile.power
@@ -1,6 +1,8 @@
 # DebugBox — Power variant
 # Advanced SRE-grade debugging and network forensics image (~104 MB).
 
+ARG BASE_IMAGE=ghcr.io/ibtisam-iq/debugbox-base:latest
+
 # Build kubectx/kubens from source
 FROM golang:1.25-alpine AS kubectx-builder
 
@@ -20,7 +22,6 @@ RUN CGO_ENABLED=0 go build -trimpath \
       -o kubens ./cmd/kubens
 
 # Runtime image
-ARG BASE_IMAGE=ghcr.io/ibtisam-iq/debugbox-base:latest
 FROM ${BASE_IMAGE}
 
 # Build args for OCI labels (passed from workflow)

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -5,8 +5,8 @@ set -eu
 # DebugBox Smoke Test
 # ------------------------------------------------------------
 
-LIB_URL="https://raw.githubusercontent.com/ibtisam-iq/infra-bootstrap/main/scripts/lib/common.sh"
-LIB_PATH="/tmp/infra-bootstrap-common.sh"
+LIB_URL="https://raw.githubusercontent.com/ibtisam-iq/silver-stack/main/scripts/lib/common.sh"
+LIB_PATH="/tmp/silver-stack-common.sh"
 LIB_LOADED=false
 
 cleanup() {
@@ -26,10 +26,10 @@ if command -v curl >/dev/null 2>&1; then
         . "$LIB_PATH"
         LIB_LOADED=true
     else
-        echo "[WARNING] Failed to download infra-bootstrap common library"
+        echo "[WARNING] Failed to download silver-stack common library"
     fi
 else
-    echo "[WARNING] curl not available to download infra-bootstrap common library"
+    echo "[WARNING] curl not available to download silver-stack common library"
 fi
 
 # Fallbacks ONLY if library not loaded
@@ -41,7 +41,7 @@ if [ "$LIB_LOADED" != "true" ]; then
 fi
 
 # ------------------------------------------------------------
-banner "infra-bootstrap - DebugBox smoke test started"
+banner "silver-stack - DebugBox smoke test started"
 
 info "User identity"
 USER_NAME="$(whoami)"
@@ -87,4 +87,4 @@ rm /tmp/smoke-test
 ok "Filesystem check passed"
 blank
 
-banner "infra-bootstrap - DebugBox smoke test PASSED"
+banner "silver-stack - DebugBox smoke test PASSED"


### PR DESCRIPTION
## Summary

- **Fix `make build-all` failure**: the previous default `PLATFORM=linux/amd64,linux/arm64` caused Docker Buildx `--load` to fail because it does not support loading multi-platform manifests into the local daemon. `PLATFORM` now auto-detects the host architecture via `uname -m`, so builds work out of the box on both Intel and Apple Silicon.
- **Add `make run-<variant>` target**: launches an interactive container session for any built variant, improving the local development loop.
- **Update smoke test library reference**: `tests/smoke.sh` now references `silver-stack` instead of the renamed `infra-bootstrap` repository.

## Test plan

- [ ] Run `make build-balanced` on the host machine and confirm it succeeds
- [ ] Run `make run-balanced` after building and confirm an interactive shell opens
- [ ] Run `make help` and confirm the new run section and updated PLATFORM description appear
- [ ] Run `PLATFORM=linux/amd64 make build-lite` to confirm explicit override still works
- [ ] Run `make test-balanced` and confirm the smoke test executes (silver-stack reference)