### PR TITLE
Phase 3: Contributor experience and project polish

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - docs
+    commit-message:
+      prefix: "docs"

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,5 +1,9 @@
 failure-threshold: error
 ignored:
+  # DL3006: FROM uses a variable (${BASE_IMAGE}) which Hadolint cannot resolve
   - DL3006
+  # DL3018: apk packages are not version-pinned; Alpine rolling releases
+  # make pinning impractical and we rebuild on every release anyway
   - DL3018
+  # DL4006: pipe failure; our RUN commands handle errors via set -eux
   - DL4006

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,9 +1,3 @@
-# kubens upstream dependencies
-# These CVEs originate from golang.org/x/net and golang.org/x/oauth2
-# embedded in kubens static binary.
-# They are not exploitable in DebugBox runtime context.
-
-CVE-2023-39325
-CVE-2025-22868
-CVE-2025-61728
-CVE-2025-61726
+# No suppressed CVEs at this time.
+# All previously ignored vulnerabilities have been resolved.
+# Add entries here only with justification documented in SECURITY.md.

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-debugbox.ibtisam-iq.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,10 @@ Welcome! 👋 Documentation fixes and small improvements are great starting poin
 
 ### 1. Fork and Clone
 ```bash
-git clone https://github.com/ibtisam-iq/debugbox.git
+# Fork via GitHub UI, then clone your fork
+git clone https://github.com/<your-username>/debugbox.git
 cd debugbox
+git remote add upstream https://github.com/ibtisam-iq/debugbox.git
 ```
 
 ### 2. Create a Feature Branch

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -462,6 +462,6 @@ Open an issue: [https://github.com/ibtisam-iq/debugbox/issues](https://github.co
 
 ---
 
-**Last Updated:** February 1, 2026  
-**Maintained By:** DebugBox Core Team  
+**Last Updated:** July 2026  
+**Maintained By:** Muhammad Ibtisam ([@ibtisam-iq](https://github.com/ibtisam-iq))  
 **Release Strategy:** Variant-first tagging with version aliases (20 tags per release)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,31 +75,12 @@ docker run -it --user 1000:1000 ghcr.io/ibtisam-iq/debugbox:lite
 
 ## Known Ignored Vulnerabilities
 
-We use automated Trivy scanning on every build/release to block HIGH/CRITICAL vulnerabilities in the Alpine base and most dependencies. However, some static Go binaries (specifically **kubens** from ahmetb/kubectx) embed older versions of third-party Go modules:
+All previously listed CVEs (CVE-2023-39325, CVE-2025-22868 in kubectx; CVE-2025-61728, CVE-2025-61726 in yq) have been resolved:
 
-- `golang.org/x/net` (v0.8.0)
-- `golang.org/x/oauth2` (pre-v0.27.0)
+- **kubectx/kubens**: Bumped to v0.11.0 and patched `golang.org/x/net` to v0.55.0 at build time.
+- **yq**: Bumped to v4.53.3 (compiled with Go 1.26.4).
 
-These trigger the following HIGH-severity findings in Trivy:
-
-- **CVE-2023-39325** (HTTP/2 rapid stream resets causing server resource exhaustion)  
-  - Fixed in golang.org/x/net v0.17.0  
-  - **Why ignored**: This is a server-side DoS vulnerability. kubens is a client-only tool with no exposed HTTP/2 server in DebugBox containers. Not exploitable in our runtime context (ephemeral debug pods).
-
-- **CVE-2025-22868** (Unexpected memory consumption during malformed token parsing in oauth2/jws)  
-  - Fixed in golang.org/x/oauth2 v0.27.0  
-  - **Why ignored**: kubens may parse OAuth tokens, but in DebugBox usage (trusted Kubernetes clusters, no untrusted inputs), malformed tokens from attackers are not a realistic threat vector. Low exploitability in isolated debug sessions.
-
-- **CVE-2025-61728** (HIGH) in yq binary (golang stdlib archive/zip DoS via malicious ZIP index)
-  - Fixed in Go 1.25.6 / 1.24.12
-  - **Why ignored**: yq in DebugBox processes trusted Kubernetes YAML output only — no malicious ZIP archives fed to it. Low exploitability in ephemeral debug pods.  
-- **CVE-2025-61726** (HIGH) in yq binary (golang stdlib net/url DoS via unlimited path segments)
-  - Fixed in Go 1.25.6 / 1.24.12
-  - **Why ignored**: yq only parses trusted Kubernetes manifests/logs in ephemeral debug containers. No untrusted/malicious URLs are fed to yq. Low to no exploitability in intended use.
-  
-These are suppressed via `.trivyignore` (see repository root) to avoid false-positive build failures. The kubectx project has not yet bumped these dependencies in recent releases (last stable v0.9.5 from 2023). We monitor upstream and will rebuild with updated versions if they become available or if risk assessment changes.
-
-For full transparency, these are **not** vulnerabilities in the DebugBox base or core tooling — only in one optional utility binary.
+All three variants currently pass Trivy scanning with zero HIGH/CRITICAL findings. If new vulnerabilities are discovered, they will be documented here with justification if suppressed.
 
 ---
 
@@ -132,5 +113,5 @@ Thank you to security researchers who report issues responsibly.
 
 ---
 
-**Last Updated:** January 31, 2026  
-**Maintained By:** DebugBox Core Team
+**Last Updated:** July 2026  
+**Maintained By:** Muhammad Ibtisam ([@ibtisam-iq](https://github.com/ibtisam-iq))

--- a/examples/balanced-debug-pod.yaml
+++ b/examples/balanced-debug-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: debug-balanced
+  labels:
+    app: debugbox
+    variant: balanced
+spec:
+  containers:
+  - name: debugbox
+    image: ghcr.io/ibtisam-iq/debugbox:balanced
+    command: ["/bin/bash"]
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+    tty: true
+    stdin: true
+  restartPolicy: Never

--- a/examples/balanced-debug-pod.yaml
+++ b/examples/balanced-debug-pod.yaml
@@ -9,7 +9,7 @@ spec:
   containers:
   - name: debugbox
     image: ghcr.io/ibtisam-iq/debugbox:balanced
-    command: ["/bin/bash"]
+    command: ["/bin/bash", "-l"]
     securityContext:
       capabilities:
         add:

--- a/examples/lite-debug-pod.yaml
+++ b/examples/lite-debug-pod.yaml
@@ -9,7 +9,7 @@ spec:
   containers:
   - name: debugbox
     image: ghcr.io/ibtisam-iq/debugbox:lite
-    command: ["/bin/bash"]
+    command: ["/bin/ash", "-l"]
     tty: true
     stdin: true
   restartPolicy: Never

--- a/examples/lite-debug-pod.yaml
+++ b/examples/lite-debug-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: debug-lite
+  labels:
+    app: debugbox
+    variant: lite
+spec:
+  containers:
+  - name: debugbox
+    image: ghcr.io/ibtisam-iq/debugbox:lite
+    command: ["/bin/bash"]
+    tty: true
+    stdin: true
+  restartPolicy: Never

--- a/examples/power-debug-pod.yaml
+++ b/examples/power-debug-pod.yaml
@@ -9,7 +9,7 @@ spec:
   containers:
   - name: debugbox
     image: ghcr.io/ibtisam-iq/debugbox:power
-    command: ["/bin/bash"]
+    command: ["/bin/bash", "-l"]
     securityContext:
       # Don't use privileged unless absolutely necessary
       privileged: false


### PR DESCRIPTION
## Summary
- Fix CONTRIBUTING.md fork-and-clone to show actual fork workflow (not upstream clone)
- Replace generic "Core Team" with maintainer name in SECURITY.md and RELEASE.md
- Update SECURITY.md to reflect all previously ignored CVEs are now resolved
- Clear stale `.trivyignore` entries (kubectx and yq CVEs fixed in PR #2)
- Add Dependabot configuration for GitHub Actions and pip dependencies
- Add inline comments to `.hadolint.yaml` explaining each suppressed rule
- Add lite and balanced example pod YAMLs (power already existed)
- Remove redundant root-level CNAME file (`docs/CNAME` is authoritative for GitHub Pages)

## Test plan
- [ ] Verify CONTRIBUTING.md fork instructions render correctly
- [ ] Verify Dependabot creates its first PRs after merge
- [ ] Verify `make scan` still passes (trivyignore cleared)
- [ ] Verify GitHub Pages still works after root CNAME removal (docs/CNAME remains)