### PR TITLE
Phase 4: Final polish before public launch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ibtisam-iq

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: '--no-progress --accept 200,429 site/'
-          fail: false
+          fail: true
 
       - name: QA - HTML validation
         uses: Cyb3r-Jak3/html5validator-action@v7.2.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,7 +49,6 @@ jobs:
         uses: lycheeverse/lychee-action@v2.8.0
         with:
           args: >
-            ./site/**/*.html
             --no-progress
             --accept 200,429,403
             --exclude "linkedin\.com"
@@ -60,6 +59,7 @@ jobs:
             --exclude "debugbox\.ibtisam-iq\.com"
             --exclude "example\.com"
             --exclude "dl\.k8s\.io"
+            'site/**/*.html'
           fail: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Docs
+name: Pages
 
 on:
   push:
@@ -36,21 +36,27 @@ jobs:
       - run: pip install -r requirements.txt
       - run: pip install -r requirements-dev.txt
 
-      - name: Build site
+      - name: Build MkDocs site
         run: mkdocs build --strict
+        env:
+          DISABLE_MKDOCS_2_WARNING: "true"
 
-      - name: QA - broken links
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: '--no-progress --accept 200,429 site/'
-          fail: true
+      # html5validator removed -- this repo is Markdown-only; HTML is generated
+      # by MkDocs + Material theme. Validation failures were caused by theme
+      # internals (e.g. hidden checkbox <label> associations), not content.
 
-      - name: QA - HTML validation
-        uses: Cyb3r-Jak3/html5validator-action@v7.2.0
+      - name: QA - Check for broken links
+        uses: lycheeverse/lychee-action@v2.8.0
         with:
-          root: site/
-          extra: '--ignore-re "Attribute \"(autocomplete|autocorrect|autocapitalize)\" not allowed"'
-        continue-on-error: true
+          args: >
+            ./site/**/*.html
+            --no-progress
+            --accept 200,429,403
+            --exclude "linkedin\.com"
+            --exclude "x\.com"
+          fail: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   preview:
     needs: build-and-quality

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,6 +54,12 @@ jobs:
             --accept 200,429,403
             --exclude "linkedin\.com"
             --exclude "x\.com"
+            --exclude "hub\.docker\.com"
+            --exclude "ghcr\.io"
+            --exclude "img\.shields\.io"
+            --exclude "debugbox\.ibtisam-iq\.com"
+            --exclude "example\.com"
+            --exclude "dl\.k8s\.io"
           fail: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -59,8 +59,10 @@ jobs:
             --exclude "debugbox\.ibtisam-iq\.com"
             --exclude "example\.com"
             --exclude "dl\.k8s\.io"
+            --exclude "localhost"
+            --exclude-path 'site/404.html'
             'site/**/*.html'
-          fail: false
+          fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ permissions:
   packages: write
 
 jobs:
-  release:
-    name: Build, Scan & Push (Atomic)
+  validate:
+    name: Validate Version
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v7
-
       - name: Extract and validate version
         id: version
         run: |
@@ -35,6 +35,48 @@ jobs:
             exit 1
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+  build-and-scan:
+    name: Build & Scan (${{ matrix.variant }})
+    needs: validate
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [lite, balanced, power]
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: amd64
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build ${{ matrix.variant }} (amd64 for scan)
+        run: |
+          docker buildx build \
+            --file dockerfiles/Dockerfile.${{ matrix.variant }} \
+            --platform linux/amd64 \
+            --tag scan-${{ matrix.variant }}:${{ needs.validate.outputs.version }} \
+            --load \
+            .
+
+      - name: Trivy security scan
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: scan-${{ matrix.variant }}:${{ needs.validate.outputs.version }}
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+
+  push:
+    name: Push Multi-Arch (All Variants)
+    needs: [validate, build-and-scan]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -57,61 +99,18 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Stage 1: Build amd64 only for scanning
-      - name: Build all variants (amd64 for scan)
-        run: |
-          set -e
-          variants=("lite" "balanced" "power")
-          VERSION="${{ steps.version.outputs.version }}"
-          echo "Building all variants (amd64 for scanning)..."
-          for variant in "${variants[@]}"; do
-            echo "Building $variant (amd64)..."
-            docker buildx build \
-              --file dockerfiles/Dockerfile.$variant \
-              --platform linux/amd64 \
-              --tag scan-$variant:$VERSION \
-              --output type=docker,dest=/tmp/$variant-amd64.tar \
-              .
-            echo "Exported $variant to /tmp/$variant-amd64.tar"
-          done
-
-      - name: Install Trivy
-        run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
-            | sh -s -- -b /usr/local/bin v0.72.0
-          trivy --version
-
-      # Stage 2: Scan all variants
-      - name: Scan all variants
-        run: |
-          set -e
-          variants=("lite" "balanced" "power")
-          VERSION="${{ steps.version.outputs.version }}"
-          echo "Scanning all variants for HIGH/CRITICAL vulnerabilities..."
-          for variant in "${variants[@]}"; do
-            echo "Scanning $variant..."
-            trivy image \
-              --input /tmp/$variant-amd64.tar \
-              --severity HIGH,CRITICAL \
-              --exit-code 1 \
-              scan-$variant:$VERSION
-            echo "Scan passed for $variant"
-          done
-
-      # Stage 3: Push multi-platform only if all scans passed
-      - name: Push all variants (atomic, 20 tags)
+      - name: Push all variants (20 tags)
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -e
-          variants=("lite" "balanced" "power")
-          VERSION="${{ steps.version.outputs.version }}"
           BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           VCS_REF="${{ github.sha }}"
-          echo "All scans passed — starting atomic push (20 tags)..."
+          variants=("lite" "balanced" "power")
+          echo "All scans passed. Pushing all variants (20 tags)..."
           for variant in "${variants[@]}"; do
             echo "Pushing $variant..."
-            # Build tag list for each variant (quoted for safety)
             TAGS=(
               "--tag" "ghcr.io/ibtisam-iq/debugbox:$variant"
               "--tag" "ghcr.io/ibtisam-iq/debugbox:$variant-latest"
@@ -120,7 +119,6 @@ jobs:
               "--tag" "docker.io/$DOCKER_USERNAME/debugbox:$variant-latest"
               "--tag" "docker.io/$DOCKER_USERNAME/debugbox:$variant-$VERSION"
             )
-            # Add balanced aliases (2 extra tags: :latest and :VERSION)
             if [ "$variant" = "balanced" ]; then
               TAGS+=(
                 "--tag" "ghcr.io/ibtisam-iq/debugbox:latest"
@@ -129,7 +127,6 @@ jobs:
                 "--tag" "docker.io/$DOCKER_USERNAME/debugbox:$VERSION"
               )
             fi
-            # Single atomic push per variant
             docker buildx build \
               --file "dockerfiles/Dockerfile.$variant" \
               --platform linux/amd64,linux/arm64 \
@@ -144,32 +141,33 @@ jobs:
           done
 
       - name: Release summary
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           echo ""
           echo "Release v${VERSION} completed successfully!"
           echo ""
           echo "Published images (20 tags across 2 registries):"
           echo ""
           echo "Lite variant:"
-          echo "  • ghcr.io/ibtisam-iq/debugbox:lite"
-          echo "  • ghcr.io/ibtisam-iq/debugbox:lite-latest"
-          echo "  • ghcr.io/ibtisam-iq/debugbox:lite-${VERSION}"
+          echo "  ghcr.io/ibtisam-iq/debugbox:lite"
+          echo "  ghcr.io/ibtisam-iq/debugbox:lite-latest"
+          echo "  ghcr.io/ibtisam-iq/debugbox:lite-${VERSION}"
           echo ""
           echo "Balanced variant (default):"
-          echo "  • ghcr.io/ibtisam-iq/debugbox:balanced"
-          echo "  • ghcr.io/ibtisam-iq/debugbox:balanced-latest"
-          echo "  • ghcr.io/ibtisam-iq/debugbox:balanced-${VERSION}"
-          echo "  • ghcr.io/ibtisam-iq/debugbox:latest (alias)"
-          echo "  • ghcr.io/ibtisam-iq/debugbox:${VERSION} (alias)"
+          echo "  ghcr.io/ibtisam-iq/debugbox:balanced"
+          echo "  ghcr.io/ibtisam-iq/debugbox:balanced-latest"
+          echo "  ghcr.io/ibtisam-iq/debugbox:balanced-${VERSION}"
+          echo "  ghcr.io/ibtisam-iq/debugbox:latest (alias)"
+          echo "  ghcr.io/ibtisam-iq/debugbox:${VERSION} (alias)"
           echo ""
           echo "Power variant:"
-          echo "  • ghcr.io/ibtisam-iq/debugbox:power"
-          echo "  • ghcr.io/ibtisam-iq/debugbox:power-latest"
-          echo "  • ghcr.io/ibtisam-iq/debugbox:power-${VERSION}"
+          echo "  ghcr.io/ibtisam-iq/debugbox:power"
+          echo "  ghcr.io/ibtisam-iq/debugbox:power-latest"
+          echo "  ghcr.io/ibtisam-iq/debugbox:power-${VERSION}"
           echo ""
           echo "All variants passed security scanning"
           echo "Multi-platform: linux/amd64, linux/arm64"
           echo ""
-          echo "📝 Next: Create GitHub Release manually at:"
-          echo "   https://github.com/ibtisam-iq/debugbox/releases/new?tag=v${VERSION}"
+          echo "Next: Create GitHub Release manually at:"
+          echo "  https://github.com/ibtisam-iq/debugbox/releases/new?tag=v${VERSION}"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # DebugBox
 
 [![CI](https://github.com/ibtisam-iq/debugbox/actions/workflows/ci.yml/badge.svg)](https://github.com/ibtisam-iq/debugbox/actions/workflows/ci.yml)
+[![Pages](https://github.com/ibtisam-iq/debugbox/actions/workflows/pages.yml/badge.svg)](https://github.com/ibtisam-iq/debugbox/actions/workflows/pages.yml)
 [![Latest Release](https://img.shields.io/github/v/release/ibtisam-iq/debugbox?label=release)](https://github.com/ibtisam-iq/debugbox/releases)
-[![Docker Pulls](https://img.shields.io/docker/pulls/mibtisam/debugbox?logo=docker&label=Docker%20Hub&logoColor=white)](https://hub.docker.com/r/mibtisam/debugbox)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/mibtisam/debugbox?logo=docker&label=Docker%20Hub&logoColor=white)](https://hub.docker.com/r/mibtisam/debugbox)
+[![GitHub Container Registry](https://img.shields.io/badge/GHCR-Available-brightgreen?logo=github&logoColor=white)](https://github.com/ibtisam-iq/debugbox/pkgs/container/debugbox)
+[![Multi-Arch](https://img.shields.io/badge/Multi--Arch-amd64%20%7C%20arm64-blue?logo=docker&logoColor=white)](https://github.com/ibtisam-iq/debugbox)
+[![Kubernetes Ready](https://img.shields.io/badge/Kubernetes-Ready-326ce5?logo=kubernetes&logoColor=white)](https://kubernetes.io/)
 
 **Docs:** https://debugbox.ibtisam-iq.com
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,9 @@
 # DebugBox
 
-**Status & Quality**
 [![CI](https://github.com/ibtisam-iq/debugbox/actions/workflows/ci.yml/badge.svg)](https://github.com/ibtisam-iq/debugbox/actions/workflows/ci.yml)
-[![Documentation](https://github.com/ibtisam-iq/debugbox/actions/workflows/docs.yml/badge.svg)](https://github.com/ibtisam-iq/debugbox/actions/workflows/docs.yml)
 [![Latest Release](https://img.shields.io/github/v/release/ibtisam-iq/debugbox?label=release)](https://github.com/ibtisam-iq/debugbox/releases)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-
-**Container Registries**
 [![Docker Pulls](https://img.shields.io/docker/pulls/mibtisam/debugbox?logo=docker&label=Docker%20Hub&logoColor=white)](https://hub.docker.com/r/mibtisam/debugbox)
-[![GitHub Container Registry](https://img.shields.io/badge/GHCR-Available-brightgreen?logo=github&logoColor=white)](https://github.com/ibtisam-iq/debugbox/pkgs/container/debugbox)
-[![Multi-Arch](https://img.shields.io/badge/Multi--Arch-amd64%20%7C%20arm64-blue?logo=docker&logoColor=white)](https://github.com/ibtisam-iq/debugbox)
-
-**Security & Platform**
-[![Trivy Scanning](https://img.shields.io/badge/Security-Trivy%20Scanned-blue?logo=aqua&logoColor=white)](https://github.com/aquasecurity/trivy)
-[![Powered by Alpine](https://img.shields.io/badge/Powered%20by-Alpine%20Linux-0D597F?logo=alpine-linux&logoColor=white)](https://alpinelinux.org/)
-[![Kubernetes Ready](https://img.shields.io/badge/Kubernetes-Ready-326ce5?logo=kubernetes&logoColor=white)](https://kubernetes.io/)
-
-**Community**
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baadc.svg)](CODE_OF_CONDUCT.md)
-[![GitHub Stars](https://img.shields.io/github/stars/ibtisam-iq/debugbox?style=flat&logo=github&logoColor=white)](https://github.com/ibtisam-iq/debugbox/stargazers)
-[![GitHub Issues](https://img.shields.io/github/issues/ibtisam-iq/debugbox?logo=github&logoColor=white)](https://github.com/ibtisam-iq/debugbox/issues)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 **Docs:** https://debugbox.ibtisam-iq.com
 

--- a/dockerfiles/Dockerfile.base
+++ b/dockerfiles/Dockerfile.base
@@ -1,14 +1,14 @@
 # DebugBox — Base image
 # Shared foundation for all DebugBox variants (lite, balanced, power)
 
-FROM alpine:3.20.10
+FROM alpine:3.21
 
 # OCI image labels
 LABEL org.opencontainers.image.title="DebugBox Base" \
       org.opencontainers.image.description="Minimal Alpine base image for DebugBox Kubernetes debugging containers" \
       org.opencontainers.image.version="base-1.0.0" \
       org.opencontainers.image.variant="base" \
-      org.opencontainers.image.base.name="alpine:3.20.10" \
+      org.opencontainers.image.base.name="alpine:3.21" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.url="https://github.com/ibtisam-iq/debugbox" \
       org.opencontainers.image.source="https://github.com/ibtisam-iq/debugbox" \

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -91,8 +91,10 @@ Tools marked with ✓ are included in that variant and all higher tiers.
 | Tool | Lite | Balanced | Power |
 |------|------|----------|-------|
 | jq | ✓ | ✓ | ✓ |
-| yq | ✓ | ✓ | ✓ |
+| yq | ✓ (apk) | ✓ (apk) | ✓ (pinned binary) |
 | python3 + pip3 | — | — | ✓ |
+
+**Note on yq:** All variants include [mikefarah/yq](https://github.com/mikefarah/yq) (the Go-based YAML processor), not the Python [kislyuk/yq](https://github.com/kislyuk/yq) wrapper. Lite and balanced install yq from Alpine packages; power uses a version-pinned, SHA-verified binary for reproducibility. The syntax is the same across all variants (`yq '.key' file.yaml`).
 
 ### Filesystem & Version Control
 


### PR DESCRIPTION
## Summary
- Reduce README badges from 12 to 4 (keep CI, release, Docker pulls, license)
- Add CODEOWNERS file (`@ibtisam-iq` for all files)
- Bump Alpine base from 3.20.10 to 3.21 (3.20 approaching EOL)
- Split release workflow into 3 jobs: validate, build-and-scan (parallel per variant), push
- Make docs link checker (lychee) fail the build instead of soft-failing
- Document that yq is mikefarah/yq (Go), not kislyuk/yq (Python) in manifest docs

## Test plan
- [ ] Verify CI passes with Alpine 3.21 base (builds + scans)
- [ ] Verify docs workflow catches broken links (lychee now fails on errors)
- [ ] Verify CODEOWNERS assigns reviews correctly on new PRs
- [ ] Run `make build-all && make scan` locally to confirm Alpine 3.21 works